### PR TITLE
Added legends and removed city layer bug

### DIFF
--- a/leaflet-openweathermap.js
+++ b/leaflet-openweathermap.js
@@ -341,6 +341,7 @@ L.OWM.Current = L.Class.extend({
 
 		if (this._map.getZoom() < this.options.minZoom) {
 			this.fire('owmloadingend', {type: _this.options.type});
+			this._layer.clearLayers();
 			// Info to user?
 			return;
 		}


### PR DESCRIPTION
Added legend for temperature, snow and wind layers.

There where a bug in the city layer:
When you zoom out to a map zoom lever lower than options min zoom, markers are not removed from map.
